### PR TITLE
Update unknown char max length default.

### DIFF
--- a/tap_mssql/__init__.py
+++ b/tap_mssql/__init__.py
@@ -216,7 +216,7 @@ def discover_catalog(mssql_conn, config):
                     c.table_name,
                     c.column_name,
                     data_type,
-                    case when character_maximum_length = -1 then 65535 else character_maximum_length end as character_maximum_length,
+                    case when character_maximum_length = -1 then 2147483647 else character_maximum_length end as character_maximum_length,
                     numeric_precision,
                     numeric_scale,
                     case when cc.column_name is null then 0 else 1 end


### PR DESCRIPTION
To account for large varchar(max)/text fields, increase default maximum.

Closes #7 